### PR TITLE
Allow date to be specified in query parameters

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+/.github
+/dist
+/Google Apps Script
+/node_modules

--- a/src/calendar/calendarRenderer.ts
+++ b/src/calendar/calendarRenderer.ts
@@ -1,5 +1,5 @@
-import { holidays, month_str as monthStr } from "./calendar.json";
-import { addStringLeftToLength } from "../common/util";
+import { holidays, month_str as monthStr } from './calendar.json';
+import { addStringLeftToLength } from '../common/util';
 
 class CalendarDate {
   year: number;
@@ -20,7 +20,7 @@ class CalendarDate {
     return new CalendarDate(
       date.getFullYear(),
       date.getMonth() + 1,
-      date.getDate(),
+      date.getDate()
     );
   }
 
@@ -33,9 +33,13 @@ class CalendarDate {
   }
 
   toString() {
-    return addStringLeftToLength(this.year.toString(), 4, "0") +
-      "-" + addStringLeftToLength(this.month.toString(), 2, "0") +
-      "-" + addStringLeftToLength(this.date.toString(), 2, "0");
+    return (
+      addStringLeftToLength(this.year.toString(), 4, '0') +
+      '-' +
+      addStringLeftToLength(this.month.toString(), 2, '0') +
+      '-' +
+      addStringLeftToLength(this.date.toString(), 2, '0')
+    );
   }
 }
 
@@ -54,7 +58,7 @@ class CalendarRenderer {
     elYear: HTMLElement,
     elDaysTbody: HTMLElement,
     dateShowing: CalendarDate,
-    onRenderEnded?: () => void,
+    onRenderEnded?: () => void
   ) {
     this.elMonthNum = elMonthNum;
     this.elMonthStr = elMonthStr;
@@ -67,13 +71,13 @@ class CalendarRenderer {
   cellLinkClickListener = (e: MouseEvent) => {
     const cel = (e.target as HTMLElement)?.parentElement;
     if (!cel) {
-      throw Error("Failed to get calendar table cel");
+      throw Error('Failed to get calendar table cel');
     }
 
     this.dateShowing = new CalendarDate(
       this.dateShowing.year,
       this.dateShowing.month,
-      parseInt(cel.dataset.date ?? "1"),
+      parseInt(cel.dataset.date ?? '1')
     );
     this.render();
   };
@@ -84,7 +88,7 @@ class CalendarRenderer {
     this.elMonthNum.innerHTML = `${this.dateShowing.month}`;
     this.elMonthStr.innerHTML = monthStr[monthKey].long;
     this.elYear.innerHTML = `${this.dateShowing.year}`;
-    this.elDaysTbody.innerHTML = "";
+    this.elDaysTbody.innerHTML = '';
 
     // create Date with month=monthIndex + 1 and day=0 and get date
     // to get the last day of the month
@@ -92,13 +96,13 @@ class CalendarRenderer {
     const monthEnd = new Date(
       this.dateShowing.year,
       this.dateShowing.month,
-      0,
+      0
     ).getDate();
     // day of the week on the first day of the month
     const weekOfDayFirstDay = new Date(
       this.dateShowing.year,
       this.dateShowing.month - 1,
-      1,
+      1
     ).getDay();
 
     const holidayNames = new Array(monthEnd).fill(undefined) as (
@@ -119,10 +123,11 @@ class CalendarRenderer {
 
     // Today's date if the displayed year and month match
     // the current ones, -1 otherwise
-    const dateToday = this.dateToday.year === this.dateShowing.year &&
-        this.dateToday.month === this.dateShowing.month
-      ? this.dateToday.date
-      : -1;
+    const dateToday =
+      this.dateToday.year === this.dateShowing.year &&
+      this.dateToday.month === this.dateShowing.month
+        ? this.dateToday.date
+        : -1;
     // create calendar table (number[][])
     // [[-1,  0,  1,  2,  3,  4,  5],
     //    6,  7,  8,  9, 10, 11, 12],
@@ -135,37 +140,37 @@ class CalendarRenderer {
         new Array(calendarWidth)
           .fill(0)
           .map(
-            (_, column) => row * calendarWidth + column - weekOfDayFirstDay + 1,
+            (_, column) => row * calendarWidth + column - weekOfDayFirstDay + 1
           )
       );
     const elRows = dateTable.map((row) => {
-      const elRow = document.createElement("tr");
+      const elRow = document.createElement('tr');
       const elCells = row.map((date) => {
-        const elCell = document.createElement("td");
+        const elCell = document.createElement('td');
         if (date <= 0 || monthEnd < date) {
           return elCell;
         }
 
-        const elLink = document.createElement("a");
-        elLink.href = "javascript:void(0);";
+        const elLink = document.createElement('a');
+        elLink.href = 'javascript:void(0);';
         elLink.textContent = `${date}`;
-        elLink.addEventListener("click", this.cellLinkClickListener);
+        elLink.addEventListener('click', this.cellLinkClickListener);
         elCell.appendChild(elLink);
 
         const holidayName = holidayNames[date];
         if (holidayName) {
-          const elHoliday = document.createElement("span");
+          const elHoliday = document.createElement('span');
           elHoliday.textContent = holidayName;
-          elHoliday.className = "holiday";
+          elHoliday.className = 'holiday';
           elCell.appendChild(elHoliday);
 
-          elCell.classList.add("holiday");
+          elCell.classList.add('holiday');
         }
         if (date === dateToday) {
-          elCell.classList.add("today");
+          elCell.classList.add('today');
         }
         if (date === this.dateShowing.date) {
-          elCell.classList.add("showing");
+          elCell.classList.add('showing');
         }
 
         elCell.dataset.date = date.toString();

--- a/src/calendar/calendarRenderer.ts
+++ b/src/calendar/calendarRenderer.ts
@@ -1,4 +1,5 @@
-import { holidays, month_str as monthStr } from './calendar.json';
+import { holidays, month_str as monthStr } from "./calendar.json";
+import { addStringLeftToLength } from "../common/util";
 
 class CalendarDate {
   year: number;
@@ -19,7 +20,7 @@ class CalendarDate {
     return new CalendarDate(
       date.getFullYear(),
       date.getMonth() + 1,
-      date.getDate()
+      date.getDate(),
     );
   }
 
@@ -29,6 +30,12 @@ class CalendarDate {
 
   normalized() {
     return CalendarDate.fromDate(this.toDate());
+  }
+
+  toString() {
+    return addStringLeftToLength(this.year.toString(), 4, "0") +
+      "-" + addStringLeftToLength(this.month.toString(), 2, "0") +
+      "-" + addStringLeftToLength(this.date.toString(), 2, "0");
   }
 }
 
@@ -47,7 +54,7 @@ class CalendarRenderer {
     elYear: HTMLElement,
     elDaysTbody: HTMLElement,
     dateShowing: CalendarDate,
-    onRenderEnded?: () => void
+    onRenderEnded?: () => void,
   ) {
     this.elMonthNum = elMonthNum;
     this.elMonthStr = elMonthStr;
@@ -60,13 +67,13 @@ class CalendarRenderer {
   cellLinkClickListener = (e: MouseEvent) => {
     const cel = (e.target as HTMLElement)?.parentElement;
     if (!cel) {
-      throw Error('Failed to get calendar table cel');
+      throw Error("Failed to get calendar table cel");
     }
 
     this.dateShowing = new CalendarDate(
       this.dateShowing.year,
       this.dateShowing.month,
-      parseInt(cel.dataset.date ?? '1')
+      parseInt(cel.dataset.date ?? "1"),
     );
     this.render();
   };
@@ -77,7 +84,7 @@ class CalendarRenderer {
     this.elMonthNum.innerHTML = `${this.dateShowing.month}`;
     this.elMonthStr.innerHTML = monthStr[monthKey].long;
     this.elYear.innerHTML = `${this.dateShowing.year}`;
-    this.elDaysTbody.innerHTML = '';
+    this.elDaysTbody.innerHTML = "";
 
     // create Date with month=monthIndex + 1 and day=0 and get date
     // to get the last day of the month
@@ -85,13 +92,13 @@ class CalendarRenderer {
     const monthEnd = new Date(
       this.dateShowing.year,
       this.dateShowing.month,
-      0
+      0,
     ).getDate();
     // day of the week on the first day of the month
     const weekOfDayFirstDay = new Date(
       this.dateShowing.year,
       this.dateShowing.month - 1,
-      1
+      1,
     ).getDay();
 
     const holidayNames = new Array(monthEnd).fill(undefined) as (
@@ -112,11 +119,10 @@ class CalendarRenderer {
 
     // Today's date if the displayed year and month match
     // the current ones, -1 otherwise
-    const dateToday =
-      this.dateToday.year === this.dateShowing.year &&
-      this.dateToday.month === this.dateShowing.month
-        ? this.dateToday.date
-        : -1;
+    const dateToday = this.dateToday.year === this.dateShowing.year &&
+        this.dateToday.month === this.dateShowing.month
+      ? this.dateToday.date
+      : -1;
     // create calendar table (number[][])
     // [[-1,  0,  1,  2,  3,  4,  5],
     //    6,  7,  8,  9, 10, 11, 12],
@@ -129,37 +135,37 @@ class CalendarRenderer {
         new Array(calendarWidth)
           .fill(0)
           .map(
-            (_, column) => row * calendarWidth + column - weekOfDayFirstDay + 1
+            (_, column) => row * calendarWidth + column - weekOfDayFirstDay + 1,
           )
       );
     const elRows = dateTable.map((row) => {
-      const elRow = document.createElement('tr');
+      const elRow = document.createElement("tr");
       const elCells = row.map((date) => {
-        const elCell = document.createElement('td');
+        const elCell = document.createElement("td");
         if (date <= 0 || monthEnd < date) {
           return elCell;
         }
 
-        const elLink = document.createElement('a');
-        elLink.href = 'javascript:void(0);';
+        const elLink = document.createElement("a");
+        elLink.href = "javascript:void(0);";
         elLink.textContent = `${date}`;
-        elLink.addEventListener('click', this.cellLinkClickListener);
+        elLink.addEventListener("click", this.cellLinkClickListener);
         elCell.appendChild(elLink);
 
         const holidayName = holidayNames[date];
         if (holidayName) {
-          const elHoliday = document.createElement('span');
+          const elHoliday = document.createElement("span");
           elHoliday.textContent = holidayName;
-          elHoliday.className = 'holiday';
+          elHoliday.className = "holiday";
           elCell.appendChild(elHoliday);
 
-          elCell.classList.add('holiday');
+          elCell.classList.add("holiday");
         }
         if (date === dateToday) {
-          elCell.classList.add('today');
+          elCell.classList.add("today");
         }
         if (date === this.dateShowing.date) {
-          elCell.classList.add('showing');
+          elCell.classList.add("showing");
         }
 
         elCell.dataset.date = date.toString();

--- a/src/calendar/main.ts
+++ b/src/calendar/main.ts
@@ -72,12 +72,23 @@ window.addEventListener('load', () => {
     });
   };
 
+  // process query
+  let date = new Date;
+  const query = location.search.slice(1).split('&');
+  for(const qStr of query) {
+    const dateMatch = /^date=(\d{4}-\d{2}-\d{2})$/.exec(qStr);
+    if(dateMatch !== null) {
+      date = new Date(dateMatch[1]);
+      continue;
+    }
+  }
+
   const renderer = new CalendarRenderer(
     elMonthNum,
     elMonthStr,
     elYearNum,
     elDaysTbody,
-    CalendarDate.fromDate(new Date()),
+    CalendarDate.fromDate(date),
     function () {
       renderImage();
     }

--- a/src/calendar/main.ts
+++ b/src/calendar/main.ts
@@ -1,13 +1,13 @@
-import { getElementByIdOrThrow } from "../common/util";
-import { CalendarDate, CalendarRenderer } from "./calendarRenderer";
+import { getElementByIdOrThrow } from '../common/util';
+import { CalendarDate, CalendarRenderer } from './calendarRenderer';
 
 const imageIndexUrl = new URL(
-  "imageIndex.json",
-  location.origin + location.pathname,
+  'imageIndex.json',
+  location.origin + location.pathname
 );
 const defaultImageUrl = new URL(
-  "imgs/calendar_default.png",
-  location.origin + location.pathname,
+  'imgs/calendar_default.png',
+  location.origin + location.pathname
 );
 let imageIndex: Record<string, string> | null = null;
 
@@ -53,40 +53,42 @@ const createDateLinkUrl = function (date: CalendarDate) {
   const baseUrl = location.href.slice(0, -query.length);
 
   // remove query of date=xxxx-xx-xx
-  const params = query.slice(1).split("&")
+  const params = query
+    .slice(1)
+    .split('&')
     .filter((param) => !/^date=(\d{4}-\d{2}-\d{2})$/.test(param));
   params.unshift(`date=${date.toString()}`);
 
-  return `${baseUrl}?${params.join("&")}`;
+  return `${baseUrl}?${params.join('&')}`;
 };
 
-window.addEventListener("load", () => {
-  const elMonthNum = getElementByIdOrThrow("calendar_month_number");
-  const elMonthStr = getElementByIdOrThrow("calendar_month_string");
-  const elYearNum = getElementByIdOrThrow("calendar_year_number");
-  const elDaysTbody = getElementByIdOrThrow("calendar_days_tbody");
-  const elMonthPrev = getElementByIdOrThrow("calendar_month_prev");
-  const elMonthNext = getElementByIdOrThrow("calendar_month_next");
-  const elYearPrev = getElementByIdOrThrow("calendar_year_prev");
-  const elYearNext = getElementByIdOrThrow("calendar_year_next");
-  const elImage = getElementByIdOrThrow("calendar_image") as HTMLImageElement;
-  const elLoader = getElementByIdOrThrow("loader");
+window.addEventListener('load', () => {
+  const elMonthNum = getElementByIdOrThrow('calendar_month_number');
+  const elMonthStr = getElementByIdOrThrow('calendar_month_string');
+  const elYearNum = getElementByIdOrThrow('calendar_year_number');
+  const elDaysTbody = getElementByIdOrThrow('calendar_days_tbody');
+  const elMonthPrev = getElementByIdOrThrow('calendar_month_prev');
+  const elMonthNext = getElementByIdOrThrow('calendar_month_next');
+  const elYearPrev = getElementByIdOrThrow('calendar_year_prev');
+  const elYearNext = getElementByIdOrThrow('calendar_year_next');
+  const elImage = getElementByIdOrThrow('calendar_image') as HTMLImageElement;
+  const elLoader = getElementByIdOrThrow('loader');
 
   const renderImage = function () {
-    elLoader.classList.remove("hidden");
+    elLoader.classList.remove('hidden');
     getImageUrl(
       renderer.dateShowing.year,
       renderer.dateShowing.month,
-      renderer.dateShowing.date,
+      renderer.dateShowing.date
     ).then((url) => {
       elImage.src = url;
-      elLoader.classList.add("hidden");
+      elLoader.classList.add('hidden');
     });
   };
 
   // process query
   let date = new Date();
-  const query = location.search.slice(1).split("&");
+  const query = location.search.slice(1).split('&');
   for (const param of query) {
     const dateMatch = /^date=(\d{4}-\d{2}-\d{2})$/.exec(param);
     if (dateMatch !== null) {
@@ -104,44 +106,44 @@ window.addEventListener("load", () => {
     function () {
       window.history.replaceState(
         renderer.dateShowing,
-        "",
-        createDateLinkUrl(renderer.dateShowing),
+        '',
+        createDateLinkUrl(renderer.dateShowing)
       );
       renderImage();
-    },
+    }
   );
   renderer.render();
 
   // set month and year switch button listener
-  elMonthPrev.addEventListener("click", () => {
+  elMonthPrev.addEventListener('click', () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year,
       renderer.dateShowing.month - 1,
-      renderer.dateShowing.date,
+      renderer.dateShowing.date
     ).normalized();
     renderer.render();
   });
-  elMonthNext.addEventListener("click", () => {
+  elMonthNext.addEventListener('click', () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year,
       renderer.dateShowing.month + 1,
-      renderer.dateShowing.date,
+      renderer.dateShowing.date
     ).normalized();
     renderer.render();
   });
-  elYearPrev.addEventListener("click", () => {
+  elYearPrev.addEventListener('click', () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year - 1,
       renderer.dateShowing.month,
-      renderer.dateShowing.date,
+      renderer.dateShowing.date
     ).normalized();
     renderer.render();
   });
-  elYearNext.addEventListener("click", () => {
+  elYearNext.addEventListener('click', () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year + 1,
       renderer.dateShowing.month,
-      renderer.dateShowing.date,
+      renderer.dateShowing.date
     ).normalized();
     renderer.render();
   });

--- a/src/calendar/main.ts
+++ b/src/calendar/main.ts
@@ -1,13 +1,13 @@
-import { getElementByIdOrThrow } from '../common/util';
-import { CalendarDate, CalendarRenderer } from './calendarRenderer';
+import { getElementByIdOrThrow } from "../common/util";
+import { CalendarDate, CalendarRenderer } from "./calendarRenderer";
 
 const imageIndexUrl = new URL(
-  'imageIndex.json',
-  location.origin + location.pathname
+  "imageIndex.json",
+  location.origin + location.pathname,
 );
 const defaultImageUrl = new URL(
-  'imgs/calendar_default.png',
-  location.origin + location.pathname
+  "imgs/calendar_default.png",
+  location.origin + location.pathname,
 );
 let imageIndex: Record<string, string> | null = null;
 
@@ -48,36 +48,48 @@ const getImageUrl = async function (year: number, month: number, day: number) {
   return url;
 };
 
-window.addEventListener('load', () => {
-  const elMonthNum = getElementByIdOrThrow('calendar_month_number');
-  const elMonthStr = getElementByIdOrThrow('calendar_month_string');
-  const elYearNum = getElementByIdOrThrow('calendar_year_number');
-  const elDaysTbody = getElementByIdOrThrow('calendar_days_tbody');
-  const elMonthPrev = getElementByIdOrThrow('calendar_month_prev');
-  const elMonthNext = getElementByIdOrThrow('calendar_month_next');
-  const elYearPrev = getElementByIdOrThrow('calendar_year_prev');
-  const elYearNext = getElementByIdOrThrow('calendar_year_next');
-  const elImage = getElementByIdOrThrow('calendar_image') as HTMLImageElement;
-  const elLoader = getElementByIdOrThrow('loader');
+const createDateLinkUrl = function (date: CalendarDate) {
+  const query = location.search;
+  const baseUrl = location.href.slice(0, -query.length);
+
+  // remove query of date=xxxx-xx-xx
+  const params = query.slice(1).split("&")
+    .filter((param) => !/^date=(\d{4}-\d{2}-\d{2})$/.test(param));
+  params.unshift(`date=${date.toString()}`);
+
+  return `${baseUrl}?${params.join("&")}`;
+};
+
+window.addEventListener("load", () => {
+  const elMonthNum = getElementByIdOrThrow("calendar_month_number");
+  const elMonthStr = getElementByIdOrThrow("calendar_month_string");
+  const elYearNum = getElementByIdOrThrow("calendar_year_number");
+  const elDaysTbody = getElementByIdOrThrow("calendar_days_tbody");
+  const elMonthPrev = getElementByIdOrThrow("calendar_month_prev");
+  const elMonthNext = getElementByIdOrThrow("calendar_month_next");
+  const elYearPrev = getElementByIdOrThrow("calendar_year_prev");
+  const elYearNext = getElementByIdOrThrow("calendar_year_next");
+  const elImage = getElementByIdOrThrow("calendar_image") as HTMLImageElement;
+  const elLoader = getElementByIdOrThrow("loader");
 
   const renderImage = function () {
-    elLoader.classList.remove('hidden');
+    elLoader.classList.remove("hidden");
     getImageUrl(
       renderer.dateShowing.year,
       renderer.dateShowing.month,
-      renderer.dateShowing.date
+      renderer.dateShowing.date,
     ).then((url) => {
       elImage.src = url;
-      elLoader.classList.add('hidden');
+      elLoader.classList.add("hidden");
     });
   };
 
   // process query
-  let date = new Date;
-  const query = location.search.slice(1).split('&');
-  for(const qStr of query) {
-    const dateMatch = /^date=(\d{4}-\d{2}-\d{2})$/.exec(qStr);
-    if(dateMatch !== null) {
+  let date = new Date();
+  const query = location.search.slice(1).split("&");
+  for (const param of query) {
+    const dateMatch = /^date=(\d{4}-\d{2}-\d{2})$/.exec(param);
+    if (dateMatch !== null) {
       date = new Date(dateMatch[1]);
       continue;
     }
@@ -90,41 +102,46 @@ window.addEventListener('load', () => {
     elDaysTbody,
     CalendarDate.fromDate(date),
     function () {
+      window.history.replaceState(
+        renderer.dateShowing,
+        "",
+        createDateLinkUrl(renderer.dateShowing),
+      );
       renderImage();
-    }
+    },
   );
   renderer.render();
 
   // set month and year switch button listener
-  elMonthPrev.addEventListener('click', () => {
+  elMonthPrev.addEventListener("click", () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year,
       renderer.dateShowing.month - 1,
-      renderer.dateShowing.date
+      renderer.dateShowing.date,
     ).normalized();
     renderer.render();
   });
-  elMonthNext.addEventListener('click', () => {
+  elMonthNext.addEventListener("click", () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year,
       renderer.dateShowing.month + 1,
-      renderer.dateShowing.date
+      renderer.dateShowing.date,
     ).normalized();
     renderer.render();
   });
-  elYearPrev.addEventListener('click', () => {
+  elYearPrev.addEventListener("click", () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year - 1,
       renderer.dateShowing.month,
-      renderer.dateShowing.date
+      renderer.dateShowing.date,
     ).normalized();
     renderer.render();
   });
-  elYearNext.addEventListener('click', () => {
+  elYearNext.addEventListener("click", () => {
     renderer.dateShowing = new CalendarDate(
       renderer.dateShowing.year + 1,
       renderer.dateShowing.month,
-      renderer.dateShowing.date
+      renderer.dateShowing.date,
     ).normalized();
     renderer.render();
   });

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -10,7 +10,7 @@ const getElementByIdOrThrow = function (id: string) {
 const addStringLeftToLength = function (
   str: string,
   length: number,
-  pad: string = ' '
+  pad = ' '
 ) {
   return (
     pad

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -7,4 +7,14 @@ const getElementByIdOrThrow = function (id: string) {
   return el;
 };
 
-export { getElementByIdOrThrow };
+const addStringLeftToLength = function (
+  str: string,
+  length: number,
+  pad: string = " ",
+) {
+  return pad.repeat(Math.floor((length - str.length) / pad.length))
+    .slice(0, length - str.length) +
+    str;
+};
+
+export { addStringLeftToLength, getElementByIdOrThrow };

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -10,11 +10,13 @@ const getElementByIdOrThrow = function (id: string) {
 const addStringLeftToLength = function (
   str: string,
   length: number,
-  pad: string = " ",
+  pad: string = ' '
 ) {
-  return pad.repeat(Math.floor((length - str.length) / pad.length))
-    .slice(0, length - str.length) +
-    str;
+  return (
+    pad
+      .repeat(Math.floor((length - str.length) / pad.length))
+      .slice(0, length - str.length) + str
+  );
 };
 
 export { addStringLeftToLength, getElementByIdOrThrow };


### PR DESCRIPTION
Made it possible for users to specify date in `calendar.html` with query parameter like `calendar.html/?date=2023-01-01`.

- Added parsing query parameter on page load
- Added updating URL when switching date on calendar